### PR TITLE
Fixed Typo of  Taggable Error With Pinyin

### DIFF
--- a/src/Util.php
+++ b/src/Util.php
@@ -153,7 +153,7 @@ class Util implements TaggingUtility
 		// Normalizer tag name
 		$str = static::tagName($str);
 
-		$str = app()->make(Pinyin::class)->permlink($str);
+		$str = app()->make(Pinyin::class)->permalink($str);
 
 		return $options['lowercase'] ? mb_strtolower($str, 'UTF-8') : $str;
 	}


### PR DESCRIPTION
Fixed Error:

```
PHP Error:  Call to undefined method Overtrue/Pinyin/Pinyin::permlink() in path/vendor/estgroupe/laravel-taggable/src/Util.php on line 156
```